### PR TITLE
Display different column in reference field

### DIFF
--- a/spra-api/shared/src/main/scala/net/wiringbits/spra/api/models/AdminGetTables.scala
+++ b/spra-api/shared/src/main/scala/net/wiringbits/spra/api/models/AdminGetTables.scala
@@ -5,7 +5,13 @@ import play.api.libs.json.{Format, Json}
 object AdminGetTables {
   case class Response(data: List[Response.DatabaseTable])
   object Response {
-    case class DatabaseTable(name: String, columns: List[TableColumn], primaryKeyName: String, canBeDeleted: Boolean)
+    case class DatabaseTable(
+        name: String,
+        columns: List[TableColumn],
+        primaryKeyName: String,
+        canBeDeleted: Boolean,
+        referenceDisplayField: Option[String]
+    )
     case class TableColumn(
         name: String,
         `type`: String,

--- a/spra-play-server/src/main/resources/application.conf
+++ b/spra-play-server/src/main/resources/application.conf
@@ -28,6 +28,7 @@ dataExplorer {
       createFilter {
         requiredColumns = ["user_id", "message"]
       }
+      referenceDisplayField = "email"
     }
   }
 }

--- a/spra-play-server/src/main/scala/net/wiringbits/spra/admin/config/TableSettings.scala
+++ b/spra-play-server/src/main/scala/net/wiringbits/spra/admin/config/TableSettings.scala
@@ -40,13 +40,14 @@ case class TableSettings(
     primaryKeyDataType: PrimaryKeyDataType = PrimaryKeyDataType.UUID,
     columnTypeOverrides: Map[String, CustomDataType] = Map.empty,
     filterableColumns: List[String] = List.empty,
-    createSettings: CreateSettings = CreateSettings()
+    createSettings: CreateSettings = CreateSettings(),
+    referenceDisplayField: Option[String] = None
 ) {
   override def toString: String =
     s"""TableSettings(tableName = $tableName, primaryKeyField = $primaryKeyField, referenceField = $referenceField,
        hiddenColumns = $hiddenColumns, nonEditableColumns = $nonEditableColumns, canBeDeleted = $canBeDeleted,
        primaryKeyDataType = $primaryKeyDataType, columnTypeOverrides = $columnTypeOverrides,
-       filterableColumns = $filterableColumns, createSettings = $createSettings)"""
+       filterableColumns = $filterableColumns, createSettings = $createSettings, referenceDisplayField: $referenceDisplayField)"""
 }
 
 object TableSettings {
@@ -102,7 +103,8 @@ object TableSettings {
       createSettings = CreateSettings(
         requiredColumns = getList[String]("createFilter.requiredColumns"),
         nonRequiredColumns = getList[String]("createFilter.nonRequiredColumns")
-      )
+      ),
+      referenceDisplayField = getOption[String]("referenceDisplayField")
     )
   }
 }

--- a/spra-play-server/src/main/scala/net/wiringbits/spra/admin/utils/package.scala
+++ b/spra-play-server/src/main/scala/net/wiringbits/spra/admin/utils/package.scala
@@ -17,12 +17,6 @@ package object utils {
     }
   }
 
-  implicit class MapStringHideExt(val data: Map[String, String]) extends AnyVal {
-    def hideData(columnsToHide: List[String]): Map[String, String] = {
-      data.filterNot { case (key, _) => columnsToHide.contains(key) }
-    }
-  }
-
   def contentRangeHeader(tableName: String, queryParameters: QueryParameters, numberOfRecords: Int): String = {
     s"$tableName ${queryParameters.pagination.start}-${queryParameters.pagination.end}/$numberOfRecords"
   }

--- a/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/CreateGuesser.scala
+++ b/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/CreateGuesser.scala
@@ -38,7 +38,13 @@ object CreateGuesser {
                 reference = reference,
                 isRequired = isRequired,
                 validate = required
-              )(SelectInput(optionText = source, isRequired = isRequired, validate = required))
+              )(
+                SelectInput(
+                  optionText = props.response.referenceDisplayField.getOrElse(source),
+                  isRequired = isRequired,
+                  validate = required
+                )
+              )
           }
         }
         .getOrElse(Fragment())

--- a/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/EditGuesser.scala
+++ b/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/EditGuesser.scala
@@ -43,7 +43,7 @@ object EditGuesser {
               SelectInput(
                 source = source,
                 optionText = props.response.referenceDisplayField.getOrElse(source),
-                disabled = !field.disabled
+                disabled = field.disabled
               )
             )
         }

--- a/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/EditGuesser.scala
+++ b/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/EditGuesser.scala
@@ -39,7 +39,13 @@ object EditGuesser {
             ReferenceInput(
               source = field.name,
               reference = reference
-            )(SelectInput(optionText = source, disabled = field.disabled))
+            )(
+              SelectInput(
+                source = source,
+                optionText = props.response.referenceDisplayField.getOrElse(source),
+                disabled = !field.disabled
+              )
+            )
         }
     }
 

--- a/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/ListGuesser.scala
+++ b/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/ListGuesser.scala
@@ -35,7 +35,9 @@ object ListGuesser {
           case Image => ImageField(source = field.name, sx = styles)
           case Number => NumberField(source = field.name)
           case ColumnType.Reference(reference, source) =>
-            defaultField(reference, field.name)(TextField(source = source))
+            defaultField(reference, field.name)(
+              TextField(source = props.response.referenceDisplayField.getOrElse(source))
+            )
         }
       }
     }

--- a/spra-web/src/main/scala/net/wiringbits/spra/ui/web/facades/reactadmin/SelectInput.scala
+++ b/spra-web/src/main/scala/net/wiringbits/spra/ui/web/facades/reactadmin/SelectInput.scala
@@ -7,18 +7,20 @@ import scala.scalajs.js.|
 
 object SelectInput extends ExternalComponent {
   case class Props(
-      optionText: String = "",
+      source: String = "",
       disabled: Boolean = false,
       isRequired: Boolean = false,
-      validate: js.UndefOr[js.Any] = js.undefined
+      validate: js.UndefOr[js.Any] = js.undefined,
+      optionText: js.UndefOr[String] = js.undefined
   )
 
   def apply(
-      optionText: String = "",
+      source: String = "",
       disabled: Boolean = false,
       isRequired: Boolean = false,
-      validate: js.UndefOr[js.Any] = js.undefined
-  ): BuildingComponent[_, _] = super.apply(Props(optionText, disabled, isRequired, validate))
+      validate: js.UndefOr[js.Any] = js.undefined,
+      optionText: js.UndefOr[String] = js.undefined
+  ): BuildingComponent[_, _] = super.apply(Props(source, disabled, isRequired, validate, optionText))
 
   override val component: String | js.Object = ReactAdmin.SelectInput
 }


### PR DESCRIPTION
We can not hide the data because it will make to not render `referenceDisplayField` correctly (it shows as `undefined` in every select option)

Fixes https://github.com/wiringbits/scala-postgres-react-admin/issues/24

![image](https://github.com/wiringbits/scala-postgres-react-admin/assets/80025691/ae9b8fdc-e09b-437e-abad-7fdb6b3abacc)
![image](https://github.com/wiringbits/scala-postgres-react-admin/assets/80025691/9458dbba-5285-4af7-bad6-e0aab8f0db0c)
![image](https://github.com/wiringbits/scala-postgres-react-admin/assets/80025691/897c512b-b76a-452e-81fc-99f491c0b2fc)
