### PR TITLE
Fixed the filter functionality when the parameter is a reference.

### DIFF
--- a/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/ListGuesser.scala
+++ b/spra-web/src/main/scala/net/wiringbits/spra/ui/web/components/ListGuesser.scala
@@ -20,7 +20,7 @@ object ListGuesser {
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
     val fields = ResponseGuesser.getTypesFromResponse(props.response)
 
-    def defaultField(reference: String, source: String)(children: ReactElement*): ReactElement =
+    def defaultField(reference: String, source: String)(children: ReactElement): ReactElement =
       ReferenceField(reference = reference, source = source)(children)
 
     val widgetFields: Seq[ReactElement] = fields.map { field =>
@@ -49,7 +49,14 @@ object ListGuesser {
         case ColumnType.Image => Fragment()
         case ColumnType.Number => NumberInput(source = field.name)
         case ColumnType.Reference(reference, source) =>
-          defaultField(reference, field.name)(TextField(source = source))
+          ReferenceInput(
+            source = field.name,
+            reference = reference
+          )(
+            SelectInput(
+              optionText = props.response.referenceDisplayField.getOrElse(source)
+            )
+          )
       }
     }
 


### PR DESCRIPTION
Fixed the filter functionality when the parameter is a reference.
Fixed : Failed prop type: Invalid prop children of type array supplied to `ReferenceFieldView`, expected a single ReactElement.