### PR TITLE
Fix tests

### DIFF
--- a/spra-play-server/src/test/scala/controllers/AdminControllerSpec.scala
+++ b/spra-play-server/src/test/scala/controllers/AdminControllerSpec.scala
@@ -670,7 +670,7 @@ class AdminControllerSpec extends PlayPostgresSpec with AdminUtils {
     }
 
     "don't fail if we send a null in an optional parameter" in withApiClient { client =>
-      val json = """{"name":"wiringbits","email":null,"password":"wiringbits"}"""
+      val json = """{"name":"wiringbits","last_name":null,"email":"test@wiringbits.net","password":"wiringbits"}"""
       val path = s"/admin/tables/${usersSettings.tableName}"
       val response = POST(path, json).futureValue
       response.header.status mustBe 200
@@ -679,8 +679,9 @@ class AdminControllerSpec extends PlayPostgresSpec with AdminUtils {
         client.getTableMetadata(usersSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
 
       responseMetadata.head.nonEmpty mustBe true
+      responseMetadata.head("last_name") mustBe ""
     }
-    
+
     "return new user id" in withApiClient { implicit client =>
       val user = createUser.futureValue
       val response = client.getTableMetadata(usersSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
@@ -802,15 +803,17 @@ class AdminControllerSpec extends PlayPostgresSpec with AdminUtils {
 
     "don't fail if we send a null in an optional parameter" in withApiClient { client =>
       val name = "wiringbits"
+      val lastName = "test"
       val email = "test@wiringbits.net"
       val password = "wiringbits"
-      val request = AdminCreateTable.Request(Map("name" -> name, "email" -> email, "password" -> password))
+      val request =
+        AdminCreateTable.Request(Map("name" -> name, "last_name" -> lastName, "email" -> email, "password" -> password))
       client.createItem("users", request).futureValue
       val responseMetadata1 =
         client.getTableMetadata(usersSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
       val id = responseMetadata1.head("id")
 
-      val json = """{"email":null}"""
+      val json = """{"last_name":"null"}"""
       val path = s"/admin/tables/${usersSettings.tableName}/$id"
       val response = PUT(path, json).futureValue
       response.header.status mustBe 200
@@ -818,7 +821,7 @@ class AdminControllerSpec extends PlayPostgresSpec with AdminUtils {
       val responseMetadata2 =
         client.getTableMetadata(usersSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
 
-      responseMetadata2.head("email") mustBe ""
+      responseMetadata2.head("last_name") mustBe ""
     }
 
     "fail if the field in body doesn't exists" in withApiClient { client =>


### PR DESCRIPTION
Fix the tests so they **don't fail if we send a null in an optional parameter** (for create and update). Changed the column to which the null value is sent. The previous column (*email*) isn't optional, so it was replaced by *last_name*, which is an optional column.

For updates, it is also necessary to send the null value as a string(*"null"*).